### PR TITLE
refactor: 抽象 SQL 备份/恢复策略并消除重复实现

### DIFF
--- a/internal/data/backup.go
+++ b/internal/data/backup.go
@@ -17,7 +17,6 @@ import (
 	"github.com/acepanel/panel/v3/internal/app"
 	"github.com/acepanel/panel/v3/internal/biz"
 	"github.com/acepanel/panel/v3/pkg/config"
-	"github.com/acepanel/panel/v3/pkg/db"
 	"github.com/acepanel/panel/v3/pkg/io"
 	"github.com/acepanel/panel/v3/pkg/shell"
 	"github.com/acepanel/panel/v3/pkg/storage"
@@ -506,118 +505,12 @@ func (r *backupRepo) createWebsite(name string, storage storage.Storage, target 
 
 // createMySQL 创建 MySQL 备份
 func (r *backupRepo) createMySQL(name string, storage storage.Storage, target string) error {
-	rootPassword, err := r.setting.Get(biz.SettingKeyMySQLRootPassword)
-	if err != nil {
-		return err
-	}
-	mysql, err := db.NewMySQL("root", rootPassword, "/tmp/mysql.sock", "unix")
-	if err != nil {
-		return err
-	}
-	defer mysql.Close()
-	if exist, _ := mysql.DatabaseExists(target); !exist {
-		return errors.New(r.t.Get("database does not exist: %s", target))
-	}
-
-	// 创建用于压缩的临时目录
-	tmpDir, err := os.MkdirTemp("", "ace-backup-*")
-	if err != nil {
-		return err
-	}
-	defer func(path string) { _ = os.RemoveAll(path) }(tmpDir)
-
-	if app.IsCli {
-		fmt.Println(r.t.Get("|-Temporary directory: %s", tmpDir))
-	}
-
-	// 导出数据库
-	name = name + ".sql"
-	_ = os.Setenv("MYSQL_PWD", rootPassword)
-	if _, err = shell.Execf(`mysqldump -u root --single-transaction --quick '%s' > '%s'`, target, filepath.Join(tmpDir, name)); err != nil {
-		return err
-	}
-	_ = os.Unsetenv("MYSQL_PWD")
-
-	// 压缩备份文件
-	if err = io.Compress(tmpDir, []string{name}, filepath.Join(tmpDir, name+".zip")); err != nil {
-		return err
-	}
-
-	// 上传备份文件到存储器
-	name = name + ".zip"
-	file, err := os.Open(filepath.Join(tmpDir, name))
-	if err != nil {
-		return err
-	}
-	defer func(file *os.File) { _ = file.Close() }(file)
-
-	if err = storage.Put(filepath.Join(string(biz.BackupTypeMySQL), name), file); err != nil {
-		return err
-	}
-
-	if app.IsCli {
-		fmt.Println(r.t.Get("|-Backup file: %s", name))
-	}
-
-	return nil
+	return r.createSQLBackup(name, storage, target, r.mysqlBackupEngine())
 }
 
 // createPostgres 创建 PostgreSQL 备份
 func (r *backupRepo) createPostgres(name string, storage storage.Storage, target string) error {
-	postgresPassword, err := r.setting.Get(biz.SettingKeyPostgresPassword)
-	if err != nil {
-		return err
-	}
-	postgres, err := db.NewPostgres("postgres", postgresPassword, "127.0.0.1", 5432)
-	if err != nil {
-		return err
-	}
-	defer postgres.Close()
-	if exist, _ := postgres.DatabaseExists(target); !exist {
-		return errors.New(r.t.Get("database does not exist: %s", target))
-	}
-
-	// 创建用于压缩的临时目录
-	tmpDir, err := os.MkdirTemp("", "ace-backup-*")
-	if err != nil {
-		return err
-	}
-	defer func(path string) { _ = os.RemoveAll(path) }(tmpDir)
-
-	if app.IsCli {
-		fmt.Println(r.t.Get("|-Temporary directory: %s", tmpDir))
-	}
-
-	// 导出数据库
-	name = name + ".sql"
-	_ = os.Setenv("PGPASSWORD", postgresPassword)
-	if _, err = shell.Execf(`pg_dump -h 127.0.0.1 -U postgres '%s' > '%s'`, target, filepath.Join(tmpDir, name)); err != nil {
-		return err
-	}
-	_ = os.Unsetenv("PGPASSWORD")
-
-	// 压缩备份文件
-	if err = io.Compress(tmpDir, []string{name}, filepath.Join(tmpDir, name+".zip")); err != nil {
-		return err
-	}
-
-	// 上传备份文件到存储器
-	name = name + ".zip"
-	file, err := os.Open(filepath.Join(tmpDir, name))
-	if err != nil {
-		return err
-	}
-	defer func(file *os.File) { _ = file.Close() }(file)
-
-	if err = storage.Put(filepath.Join(string(biz.BackupTypePostgres), name), file); err != nil {
-		return err
-	}
-
-	if app.IsCli {
-		fmt.Println(r.t.Get("|-Backup file: %s", name))
-	}
-
-	return nil
+	return r.createSQLBackup(name, storage, target, r.postgresBackupEngine())
 }
 
 // restoreWebsite 恢复网站备份
@@ -645,74 +538,12 @@ func (r *backupRepo) restoreWebsite(backup, target string) error {
 
 // restoreMySQL 恢复 MySQL 备份
 func (r *backupRepo) restoreMySQL(backup, target string) error {
-	rootPassword, err := r.setting.Get(biz.SettingKeyMySQLRootPassword)
-	if err != nil {
-		return err
-	}
-	mysql, err := db.NewMySQL("root", rootPassword, "/tmp/mysql.sock", "unix")
-	if err != nil {
-		return err
-	}
-	defer mysql.Close()
-	if exist, _ := mysql.DatabaseExists(target); !exist {
-		return errors.New(r.t.Get("database does not exist: %s", target))
-	}
-
-	clean := false
-	if !strings.HasSuffix(backup, ".sql") {
-		backup, err = r.autoUnCompressSQL(backup)
-		if err != nil {
-			return err
-		}
-		clean = true
-	}
-
-	_ = os.Setenv("MYSQL_PWD", rootPassword)
-	if _, err = shell.Execf(`mysql -u root '%s' < '%s'`, target, backup); err != nil {
-		return err
-	}
-	_ = os.Unsetenv("MYSQL_PWD")
-	if clean {
-		_ = io.Remove(filepath.Dir(backup))
-	}
-
-	return nil
+	return r.restoreSQLBackup(backup, target, r.mysqlBackupEngine())
 }
 
 // restorePostgres 恢复 PostgreSQL 备份
 func (r *backupRepo) restorePostgres(backup, target string) error {
-	postgresPassword, err := r.setting.Get(biz.SettingKeyPostgresPassword)
-	if err != nil {
-		return err
-	}
-	postgres, err := db.NewPostgres("postgres", postgresPassword, "127.0.0.1", 5432)
-	if err != nil {
-		return err
-	}
-	defer postgres.Close()
-	if exist, _ := postgres.DatabaseExists(target); !exist {
-		return errors.New(r.t.Get("database does not exist: %s", target))
-	}
-
-	clean := false
-	if !strings.HasSuffix(backup, ".sql") {
-		backup, err = r.autoUnCompressSQL(backup)
-		if err != nil {
-			return err
-		}
-		clean = true
-	}
-
-	_ = os.Setenv("PGPASSWORD", postgresPassword)
-	if _, err = shell.Execf(`psql -h 127.0.0.1 -U postgres '%s' < '%s'`, target, backup); err != nil {
-		return err
-	}
-	_ = os.Unsetenv("PGPASSWORD")
-	if clean {
-		_ = io.Remove(filepath.Dir(backup))
-	}
-
-	return nil
+	return r.restoreSQLBackup(backup, target, r.postgresBackupEngine())
 }
 
 // autoUnCompressSQL 自动处理压缩文件

--- a/internal/data/backup_sql.go
+++ b/internal/data/backup_sql.go
@@ -1,0 +1,151 @@
+package data
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/acepanel/panel/v3/internal/app"
+	"github.com/acepanel/panel/v3/internal/biz"
+	"github.com/acepanel/panel/v3/pkg/db"
+	"github.com/acepanel/panel/v3/pkg/io"
+	"github.com/acepanel/panel/v3/pkg/shell"
+	"github.com/acepanel/panel/v3/pkg/storage"
+)
+
+type sqlBackupEngine struct {
+	typ         biz.BackupType
+	settingKey  biz.SettingKey
+	passwordEnv string
+	open        func(password string) (db.Operator, error)
+	dumpCmd     func(target, output string) string
+	restoreCmd  func(target, input string) string
+}
+
+func (r *backupRepo) mysqlBackupEngine() sqlBackupEngine {
+	return sqlBackupEngine{
+		typ:         biz.BackupTypeMySQL,
+		settingKey:  biz.SettingKeyMySQLRootPassword,
+		passwordEnv: "MYSQL_PWD",
+		open: func(password string) (db.Operator, error) {
+			return db.NewMySQL("root", password, "/tmp/mysql.sock", "unix")
+		},
+		dumpCmd: func(target, output string) string {
+			return fmt.Sprintf("mysqldump -u root --single-transaction --quick '%s' > '%s'", target, output)
+		},
+		restoreCmd: func(target, input string) string {
+			return fmt.Sprintf("mysql -u root '%s' < '%s'", target, input)
+		},
+	}
+}
+
+func (r *backupRepo) postgresBackupEngine() sqlBackupEngine {
+	return sqlBackupEngine{
+		typ:         biz.BackupTypePostgres,
+		settingKey:  biz.SettingKeyPostgresPassword,
+		passwordEnv: "PGPASSWORD",
+		open: func(password string) (db.Operator, error) {
+			return db.NewPostgres("postgres", password, "127.0.0.1", 5432)
+		},
+		dumpCmd: func(target, output string) string {
+			return fmt.Sprintf("pg_dump -h 127.0.0.1 -U postgres '%s' > '%s'", target, output)
+		},
+		restoreCmd: func(target, input string) string {
+			return fmt.Sprintf("psql -h 127.0.0.1 -U postgres '%s' < '%s'", target, input)
+		},
+	}
+}
+
+func (r *backupRepo) createSQLBackup(name string, client storage.Storage, target string, engine sqlBackupEngine) error {
+	password, err := r.setting.Get(engine.settingKey)
+	if err != nil {
+		return err
+	}
+
+	operator, err := engine.open(password)
+	if err != nil {
+		return err
+	}
+	defer operator.Close()
+	if exist, _ := operator.DatabaseExists(target); !exist {
+		return errors.New(r.t.Get("database does not exist: %s", target))
+	}
+
+	tmpDir, err := os.MkdirTemp("", "ace-backup-*")
+	if err != nil {
+		return err
+	}
+	defer func(path string) { _ = os.RemoveAll(path) }(tmpDir)
+
+	if app.IsCli {
+		fmt.Println(r.t.Get("|-Temporary directory: %s", tmpDir))
+	}
+
+	sqlName := name + ".sql"
+	output := filepath.Join(tmpDir, sqlName)
+	_ = os.Setenv(engine.passwordEnv, password)
+	if _, err = shell.Execf(engine.dumpCmd(target, output)); err != nil {
+		return err
+	}
+	_ = os.Unsetenv(engine.passwordEnv)
+
+	zipName := sqlName + ".zip"
+	if err = io.Compress(tmpDir, []string{sqlName}, filepath.Join(tmpDir, zipName)); err != nil {
+		return err
+	}
+
+	file, err := os.Open(filepath.Join(tmpDir, zipName))
+	if err != nil {
+		return err
+	}
+	defer func(file *os.File) { _ = file.Close() }(file)
+
+	if err = client.Put(filepath.Join(string(engine.typ), zipName), file); err != nil {
+		return err
+	}
+
+	if app.IsCli {
+		fmt.Println(r.t.Get("|-Backup file: %s", zipName))
+	}
+
+	return nil
+}
+
+func (r *backupRepo) restoreSQLBackup(backup, target string, engine sqlBackupEngine) error {
+	password, err := r.setting.Get(engine.settingKey)
+	if err != nil {
+		return err
+	}
+
+	operator, err := engine.open(password)
+	if err != nil {
+		return err
+	}
+	defer operator.Close()
+	if exist, _ := operator.DatabaseExists(target); !exist {
+		return errors.New(r.t.Get("database does not exist: %s", target))
+	}
+
+	sqlPath := backup
+	clean := false
+	if !strings.HasSuffix(sqlPath, ".sql") {
+		sqlPath, err = r.autoUnCompressSQL(backup)
+		if err != nil {
+			return err
+		}
+		clean = true
+	}
+
+	_ = os.Setenv(engine.passwordEnv, password)
+	if _, err = shell.Execf(engine.restoreCmd(target, sqlPath)); err != nil {
+		return err
+	}
+	_ = os.Unsetenv(engine.passwordEnv)
+	if clean {
+		_ = io.Remove(filepath.Dir(sqlPath))
+	}
+
+	return nil
+}


### PR DESCRIPTION
将 MySQL/PostgreSQL 的备份与恢复重复流程收敛为 internal/data 内部通用能力，新增 sqlBackupEngine 策略结构并统一 createSQLBackup/restoreSQLBackup 流程。

主要改动：
 - 新增 internal/data/backup_sql.go，封装数据库类型差异（连接、密码环境变量、dump/restore 命令、备份类型）。
 - backup.go 中保留 createMySQL/createPostgres/restoreMySQL/restorePostgres 方法名，改为薄封装调用统一流程。
 - 删除 backup.go 中重复实现与冗余导入。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **重构**
  * 统一了 MySQL 和 PostgreSQL 的数据库备份和恢复流程，优化了代码结构，减少了代码重复。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->