### PR TITLE
fix: DNS-01 challenge fails with NXDOMAIN due to missing propagation wait

### DIFF
--- a/internal/data/cert.go
+++ b/internal/data/cert.go
@@ -330,7 +330,7 @@ func (r *certRepo) Renew(id uint) (*acme.Certificate, error) {
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 	ssl, err := client.RenewCertificate(ctx, cert.CertURL, cert.Domains, acme.KeyType(cert.Type))
 	if err != nil {

--- a/pkg/acme/solvers.go
+++ b/pkg/acme/solvers.go
@@ -370,6 +370,7 @@ type dnsSolver struct {
 	dns     DnsType
 	param   DNSParam
 	records []libdns.Record
+	mu      sync.Mutex
 }
 
 func (s *dnsSolver) Present(ctx context.Context, challenge acme.Challenge) error {
@@ -393,12 +394,24 @@ func (s *dnsSolver) Present(ctx context.Context, challenge acme.Challenge) error
 	if err != nil {
 		return fmt.Errorf("failed to set DNS record %q for %q: %w", dnsName, zone, err)
 	}
-	if len(results) != 1 {
-		return fmt.Errorf("expected to add 1 record, but actually added %d records", len(results))
+	if len(results) == 0 {
+		return fmt.Errorf("DNS provider returned no records after setting %q", dnsName)
 	}
 
-	s.records = results
+	s.mu.Lock()
+	s.records = append(s.records, results...)
+	s.mu.Unlock()
 	return nil
+}
+
+// Wait 实现 acmez.Waiter 接口，等待 DNS TXT 记录传播后再通知 CA 进行验证
+func (s *dnsSolver) Wait(ctx context.Context, _ acme.Challenge) error {
+	select {
+	case <-time.After(60 * time.Second):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (s *dnsSolver) CleanUp(ctx context.Context, challenge acme.Challenge) error {
@@ -416,7 +429,11 @@ func (s *dnsSolver) CleanUp(ctx context.Context, challenge acme.Challenge) error
 		return fmt.Errorf("failed to get the effective TLD+1 for %q: %w", dnsName, err)
 	}
 
-	_, _ = provider.DeleteRecords(ctx, zone+".", s.records)
+	s.mu.Lock()
+	records := s.records
+	s.mu.Unlock()
+
+	_, _ = provider.DeleteRecords(ctx, zone+".", records)
 	return nil
 }
 


### PR DESCRIPTION
## Problem

When requesting certificates using DNS-01 challenge (e.g. Cloudflare), both wildcard domains (`*.example.com`) and subdomains (`portal.example.com`) fail with:

```
solving challenge: *.example.com: [*.example.com] authorization failed: HTTP 400
urn:ietf:params:acme:error:dns - DNS problem: NXDOMAIN looking up TXT for
_acme-challenge.example.com - check that a DNS record exists for this domain
```

## Root Cause

`dnsSolver` does not implement the `acmez.Waiter` interface. The acmez library checks for `Waiter` in `initiateCurrentChallenge` before notifying the CA to verify:

```go
if waiter, ok := authz.currentSolver.(Waiter); ok {
    waiter.Wait(ctx, authz.currentChallenge)
}
```

Without a `Wait()` method, acmez immediately tells Let's Encrypt to verify the moment `Present()` returns — before Cloudflare (or any DNS provider) has propagated the new TXT record to its authoritative nameservers. Let's Encrypt queries DNS, gets NXDOMAIN, and fails the authorization.

## Changes

**`pkg/acme/solvers.go`**
- Add `Wait(ctx, challenge)` to `dnsSolver`, implementing `acmez.Waiter` — waits 60 seconds before returning, giving DNS time to propagate before the CA verifies
- Change `s.records = results` → `append` so concurrent `Present()` calls for multi-domain certs (e.g. `*.example.com` + `example.com`) don't overwrite each other's records
- Add `sync.Mutex` to guard `records` across concurrent calls
- Relax result count check from `!= 1` to `== 0` to handle providers that return multiple records when updating an existing entry

**`internal/data/cert.go`**
- Increase `Renew` context timeout from 2 minutes → 10 minutes; the previous limit would fire before the 60s propagation wait + ACME polling could complete

## Testing

Verified against `*.zenworkflow.app` (wildcard) and `portal.zenworkflow.app` (subdomain) using Cloudflare DNS provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 提高证书续期操作的超时时限，从2分钟增加至10分钟，降低续期失败风险
  * 增强DNS验证机制的可靠性和同步处理，改进复杂网络环境下的稳定性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->