### PR TITLE
fix: 修复 shell 参数检查无法拦截内嵌特殊字符的问题

### DIFF
--- a/pkg/shell/exec.go
+++ b/pkg/shell/exec.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"slices"
 	"strings"
 	"time"
 
@@ -239,9 +238,9 @@ func ExecfWithTTY(shell string, args ...any) (string, error) {
 }
 
 func preCheckArg(args []any) bool {
-	illegals := []any{`&`, `|`, `;`, `$`, `'`, `"`, "`", `(`, `)`, "\n", "\r", `>`, `<`}
-	for arg := range slices.Values(args) {
-		if slices.Contains(illegals, arg) {
+	const illegals = "&|;$'\"`()\n\r><"
+	for _, arg := range args {
+		if strings.ContainsAny(fmt.Sprint(arg), illegals) {
 			return false
 		}
 	}


### PR DESCRIPTION
- 我在文件管理中操作包含特殊字符的路径时发现，shell.Execf 的参数检查只判断参数是否等于非法字符，没有判断字符串内部是否包含非法字符，导致类似 /www/wwwroot/site;2026 的路径仍会进入 bash -c 被重新解释。
- 本次改为使用包含判断拦截 shell 元字符，并补充单元测试覆盖该场景。

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->


<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have added test cases for my code
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  - 优化了参数验证中的字符检测机制，提升了代码效率和可维护性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/acepanel/panel/pull/1624?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->