### PR TITLE
Fix/postgresql port sync

### DIFF
--- a/cmd/ace/wire_gen.go
+++ b/cmd/ace/wire_gen.go
@@ -95,7 +95,7 @@ func initAce() (*app.Ace, error) {
 	cronRepo := data.NewCronRepo(locale, db, logger)
 	backupRepo := data.NewBackupRepo(locale, config, db, logger, settingRepo, websiteRepo)
 	containerRepo := data.NewContainerRepo(settingRepo)
-	homeService := service.NewHomeService(locale, config, taskRepo, websiteRepo, projectRepo, appRepo, environmentRepo, settingRepo, cronRepo, backupRepo, containerRepo)
+	homeService := service.NewHomeService(locale, config, taskRepo, websiteRepo, projectRepo, appRepo, environmentRepo, settingRepo, databaseServerRepo, cronRepo, backupRepo, containerRepo)
 	taskService := service.NewTaskService(taskRepo)
 	websiteService := service.NewWebsiteService(websiteRepo, settingRepo)
 	projectService := service.NewProjectService(projectRepo, settingRepo)

--- a/internal/apps/postgresql/app.go
+++ b/internal/apps/postgresql/app.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/leonelquinteros/gotext"
+	"github.com/spf13/cast"
 
 	"github.com/acepanel/panel/v3/internal/app"
 	"github.com/acepanel/panel/v3/internal/biz"
+	httprequest "github.com/acepanel/panel/v3/internal/http/request"
 	"github.com/acepanel/panel/v3/internal/service"
 	"github.com/acepanel/panel/v3/pkg/db"
 	"github.com/acepanel/panel/v3/pkg/io"
@@ -55,7 +57,7 @@ func (s *App) Status() string {
 // GetConfig 获取配置
 func (s *App) GetConfig(w http.ResponseWriter, r *http.Request) {
 	// 获取配置
-	config, err := io.Read(fmt.Sprintf("%s/server/postgresql/data/postgresql.conf", app.Root))
+	config, err := io.Read(s.configPath())
 	if err != nil {
 		service.Error(w, http.StatusInternalServerError, "%v", err)
 		return
@@ -72,13 +74,14 @@ func (s *App) UpdateConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = io.Write(fmt.Sprintf("%s/server/postgresql/data/postgresql.conf", app.Root), req.Config, 0644); err != nil {
+	oldPort := s.getPort()
+	if err = io.Write(s.configPath(), req.Config, 0644); err != nil {
 		service.Error(w, http.StatusInternalServerError, "%v", err)
 		return
 	}
 
-	if err = systemctl.Reload("postgresql"); err != nil {
-		service.Error(w, http.StatusInternalServerError, s.t.Get("failed to reload PostgreSQL: %v", err))
+	if err = s.applyConfig(req.Config, oldPort); err != nil {
+		service.Error(w, http.StatusInternalServerError, s.t.Get("failed to apply PostgreSQL config: %v", err))
 		return
 	}
 
@@ -136,13 +139,15 @@ func (s *App) Load(w http.ResponseWriter, r *http.Request) {
 		service.Error(w, http.StatusInternalServerError, s.t.Get("failed to set PGPASSWORD env: %v", err))
 		return
 	}
+	defer func() { _ = os.Unsetenv("PGPASSWORD") }()
 
-	start, err := shell.Execf(`psql -h 127.0.0.1 -U postgres -t -c "select pg_postmaster_start_time();" | head -1 | cut -d'.' -f1`)
+	port := s.getPort()
+	start, err := shell.Execf(`psql -h 127.0.0.1 -p %s -U postgres -t -c "select pg_postmaster_start_time();" | head -1 | cut -d'.' -f1`, port)
 	if err != nil {
 		service.Error(w, http.StatusInternalServerError, s.t.Get("failed to get PostgreSQL start time: %v", err))
 		return
 	}
-	pid, err := shell.Execf(`psql -h 127.0.0.1 -U postgres -t -c "select pg_backend_pid();"`)
+	pid, err := shell.Execf(`psql -h 127.0.0.1 -p %s -U postgres -t -c "select pg_backend_pid();"`, port)
 	if err != nil {
 		service.Error(w, http.StatusInternalServerError, s.t.Get("failed to get PostgreSQL backend pid: %v", err))
 		return
@@ -152,19 +157,14 @@ func (s *App) Load(w http.ResponseWriter, r *http.Request) {
 		service.Error(w, http.StatusInternalServerError, s.t.Get("failed to get PostgreSQL process: %v", err))
 		return
 	}
-	connections, err := shell.Execf(`psql -h 127.0.0.1 -U postgres -t -c "SELECT count(*) FROM pg_stat_activity WHERE NOT pid=pg_backend_pid();"`)
+	connections, err := shell.Execf(`psql -h 127.0.0.1 -p %s -U postgres -t -c "SELECT count(*) FROM pg_stat_activity WHERE NOT pid=pg_backend_pid();"`, port)
 	if err != nil {
 		service.Error(w, http.StatusInternalServerError, s.t.Get("failed to get PostgreSQL connections: %v", err))
 		return
 	}
-	storage, err := shell.Execf(`psql -h 127.0.0.1 -U postgres -t -c "select pg_size_pretty(pg_database_size('postgres'));"`)
+	storage, err := shell.Execf(`psql -h 127.0.0.1 -p %s -U postgres -t -c "select pg_size_pretty(pg_database_size('postgres'));"`, port)
 	if err != nil {
 		service.Error(w, http.StatusInternalServerError, s.t.Get("failed to get PostgreSQL database size: %v", err))
-		return
-	}
-
-	if err = os.Unsetenv("PGPASSWORD"); err != nil {
-		service.Error(w, http.StatusInternalServerError, s.t.Get("failed to unset PGPASSWORD env: %v", err))
 		return
 	}
 
@@ -210,10 +210,11 @@ func (s *App) SetPostgresPassword(w http.ResponseWriter, r *http.Request) {
 	}
 
 	oldPassword, _ := s.settingRepo.Get(biz.SettingKeyPostgresPassword)
-	postgres, err := db.NewPostgres("postgres", oldPassword, "127.0.0.1", 5432)
+	port := s.getPort()
+	postgres, err := db.NewPostgres("postgres", oldPassword, "127.0.0.1", cast.ToUint(port))
 	if err != nil {
 		// 直接修改密码
-		if _, err = shell.Execf(`su - postgres -c "psql -c \"ALTER USER postgres WITH PASSWORD '%s';\""`, req.Password); err != nil {
+		if _, err = shell.Execf(`su - postgres -c "psql -p %s -c \"ALTER USER postgres WITH PASSWORD '%s';\""`, port, req.Password); err != nil {
 			service.Error(w, http.StatusInternalServerError, s.t.Get("failed to set postgres password: %v", err))
 			return
 		}
@@ -237,7 +238,7 @@ func (s *App) SetPostgresPassword(w http.ResponseWriter, r *http.Request) {
 
 // GetConfigTune 获取 PostgreSQL 配置调整参数
 func (s *App) GetConfigTune(w http.ResponseWriter, r *http.Request) {
-	config, err := io.Read(fmt.Sprintf("%s/server/postgresql/data/postgresql.conf", app.Root))
+	config, err := io.Read(s.configPath())
 	if err != nil {
 		service.Error(w, http.StatusInternalServerError, "%v", err)
 		return
@@ -284,7 +285,8 @@ func (s *App) UpdateConfigTune(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	confPath := fmt.Sprintf("%s/server/postgresql/data/postgresql.conf", app.Root)
+	confPath := s.configPath()
+	oldPort := s.getPort()
 	config, err := io.Read(confPath)
 	if err != nil {
 		service.Error(w, http.StatusInternalServerError, "%v", err)
@@ -324,12 +326,59 @@ func (s *App) UpdateConfigTune(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = systemctl.Reload("postgresql"); err != nil {
-		service.Error(w, http.StatusInternalServerError, s.t.Get("failed to reload PostgreSQL: %v", err))
+	if err = s.applyConfig(config, oldPort); err != nil {
+		service.Error(w, http.StatusInternalServerError, s.t.Get("failed to apply PostgreSQL config: %v", err))
 		return
 	}
 
 	service.Success(w, nil)
+}
+
+func (s *App) configPath() string {
+	return fmt.Sprintf("%s/server/postgresql/data/postgresql.conf", app.Root)
+}
+
+func (s *App) getPort() string {
+	config, err := io.Read(s.configPath())
+	if err != nil {
+		return "5432"
+	}
+
+	port := s.getPGValue(config, "port")
+	if port == "" {
+		return "5432"
+	}
+
+	return port
+}
+
+func (s *App) applyConfig(config string, oldPort string) error {
+	newPort := s.getPGValue(config, "port")
+	if newPort == "" {
+		newPort = "5432"
+	}
+	if oldPort != newPort {
+		if err := systemctl.Restart("postgresql"); err != nil {
+			return err
+		}
+
+		server, err := s.databaseServerRepo.GetByName("local_postgresql")
+		if err != nil {
+			return nil
+		}
+
+		return s.databaseServerRepo.Update(&httprequest.DatabaseServerUpdate{
+			ID:       server.ID,
+			Name:     server.Name,
+			Host:     server.Host,
+			Port:     cast.ToUint(newPort),
+			Username: server.Username,
+			Password: server.Password,
+			Remark:   server.Remark,
+		})
+	}
+
+	return systemctl.Reload("postgresql")
 }
 
 // getPGValue 从 PostgreSQL 配置内容中获取指定键的值

--- a/internal/apps/postgresql/app.go
+++ b/internal/apps/postgresql/app.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/acepanel/panel/v3/internal/app"
 	"github.com/acepanel/panel/v3/internal/biz"
-	httprequest "github.com/acepanel/panel/v3/internal/http/request"
 	"github.com/acepanel/panel/v3/internal/service"
 	"github.com/acepanel/panel/v3/pkg/db"
 	"github.com/acepanel/panel/v3/pkg/io"
@@ -142,12 +141,12 @@ func (s *App) Load(w http.ResponseWriter, r *http.Request) {
 	defer func() { _ = os.Unsetenv("PGPASSWORD") }()
 
 	port := s.getPort()
-	start, err := shell.Execf(`psql -h 127.0.0.1 -p %s -U postgres -t -c "select pg_postmaster_start_time();" | head -1 | cut -d'.' -f1`, port)
+	start, err := shell.Execf(`psql -h 127.0.0.1 -p %d -U postgres -t -c "select pg_postmaster_start_time();" | head -1 | cut -d'.' -f1`, port)
 	if err != nil {
 		service.Error(w, http.StatusInternalServerError, s.t.Get("failed to get PostgreSQL start time: %v", err))
 		return
 	}
-	pid, err := shell.Execf(`psql -h 127.0.0.1 -p %s -U postgres -t -c "select pg_backend_pid();"`, port)
+	pid, err := shell.Execf(`psql -h 127.0.0.1 -p %d -U postgres -t -c "select pg_backend_pid();"`, port)
 	if err != nil {
 		service.Error(w, http.StatusInternalServerError, s.t.Get("failed to get PostgreSQL backend pid: %v", err))
 		return
@@ -157,12 +156,12 @@ func (s *App) Load(w http.ResponseWriter, r *http.Request) {
 		service.Error(w, http.StatusInternalServerError, s.t.Get("failed to get PostgreSQL process: %v", err))
 		return
 	}
-	connections, err := shell.Execf(`psql -h 127.0.0.1 -p %s -U postgres -t -c "SELECT count(*) FROM pg_stat_activity WHERE NOT pid=pg_backend_pid();"`, port)
+	connections, err := shell.Execf(`psql -h 127.0.0.1 -p %d -U postgres -t -c "SELECT count(*) FROM pg_stat_activity WHERE NOT pid=pg_backend_pid();"`, port)
 	if err != nil {
 		service.Error(w, http.StatusInternalServerError, s.t.Get("failed to get PostgreSQL connections: %v", err))
 		return
 	}
-	storage, err := shell.Execf(`psql -h 127.0.0.1 -p %s -U postgres -t -c "select pg_size_pretty(pg_database_size('postgres'));"`, port)
+	storage, err := shell.Execf(`psql -h 127.0.0.1 -p %d -U postgres -t -c "select pg_size_pretty(pg_database_size('postgres'));"`, port)
 	if err != nil {
 		service.Error(w, http.StatusInternalServerError, s.t.Get("failed to get PostgreSQL database size: %v", err))
 		return
@@ -211,10 +210,10 @@ func (s *App) SetPostgresPassword(w http.ResponseWriter, r *http.Request) {
 
 	oldPassword, _ := s.settingRepo.Get(biz.SettingKeyPostgresPassword)
 	port := s.getPort()
-	postgres, err := db.NewPostgres("postgres", oldPassword, "127.0.0.1", cast.ToUint(port))
+	postgres, err := db.NewPostgres("postgres", oldPassword, "127.0.0.1", port)
 	if err != nil {
 		// 直接修改密码
-		if _, err = shell.Execf(`su - postgres -c "psql -p %s -c \"ALTER USER postgres WITH PASSWORD '%s';\""`, port, req.Password); err != nil {
+		if _, err = shell.Execf(`su - postgres -c "psql -p %d -c \"ALTER USER postgres WITH PASSWORD '%s';\""`, port, req.Password); err != nil {
 			service.Error(w, http.StatusInternalServerError, s.t.Get("failed to set postgres password: %v", err))
 			return
 		}
@@ -338,47 +337,34 @@ func (s *App) configPath() string {
 	return fmt.Sprintf("%s/server/postgresql/data/postgresql.conf", app.Root)
 }
 
-func (s *App) getPort() string {
+// getPort 读取 PostgreSQL 端口
+func (s *App) getPort() uint {
 	config, err := io.Read(s.configPath())
 	if err != nil {
-		return "5432"
+		return 5432
 	}
+	return s.parsePort(config)
+}
 
-	port := s.getPGValue(config, "port")
-	if port == "" {
-		return "5432"
+// parsePort 从 config 内容解析端口，未配置时返回默认值
+func (s *App) parsePort(config string) uint {
+	port := cast.ToUint(s.getPGValue(config, "port"))
+	if port == 0 {
+		return 5432
 	}
-
 	return port
 }
 
-func (s *App) applyConfig(config string, oldPort string) error {
-	newPort := s.getPGValue(config, "port")
-	if newPort == "" {
-		newPort = "5432"
+// applyConfig 让 PostgreSQL 配置生效
+func (s *App) applyConfig(newConfig string, oldPort uint) error {
+	newPort := s.parsePort(newConfig)
+	if oldPort == newPort {
+		return systemctl.Reload("postgresql")
 	}
-	if oldPort != newPort {
-		if err := systemctl.Restart("postgresql"); err != nil {
-			return err
-		}
-
-		server, err := s.databaseServerRepo.GetByName("local_postgresql")
-		if err != nil {
-			return nil
-		}
-
-		return s.databaseServerRepo.Update(&httprequest.DatabaseServerUpdate{
-			ID:       server.ID,
-			Name:     server.Name,
-			Host:     server.Host,
-			Port:     cast.ToUint(newPort),
-			Username: server.Username,
-			Password: server.Password,
-			Remark:   server.Remark,
-		})
+	if err := systemctl.Restart("postgresql"); err != nil {
+		return err
 	}
-
-	return systemctl.Reload("postgresql")
+	return s.databaseServerRepo.UpdatePort("local_postgresql", newPort)
 }
 
 // getPGValue 从 PostgreSQL 配置内容中获取指定键的值

--- a/internal/biz/database_server.go
+++ b/internal/biz/database_server.go
@@ -69,6 +69,7 @@ type DatabaseServerRepo interface {
 	Update(req *request.DatabaseServerUpdate) error
 	UpdateRemark(req *request.DatabaseServerUpdateRemark) error
 	UpdatePassword(name string, password string) error
+	UpdatePort(name string, port uint) error
 	Delete(id uint) error
 	ClearUsers(id uint) error
 	Sync(id uint) error

--- a/internal/data/database_server.go
+++ b/internal/data/database_server.go
@@ -121,6 +121,10 @@ func (r *databaseServerRepo) UpdatePassword(name string, password string) error 
 	return r.db.Model(&biz.DatabaseServer{}).Where("name = ?", name).Update("password", password).Error
 }
 
+func (r *databaseServerRepo) UpdatePort(name string, port uint) error {
+	return r.db.Model(&biz.DatabaseServer{}).Where("name = ?", name).Update("port", port).Error
+}
+
 func (r *databaseServerRepo) Delete(id uint) error {
 	if err := r.ClearUsers(id); err != nil {
 		return err

--- a/internal/service/home.go
+++ b/internal/service/home.go
@@ -189,13 +189,10 @@ func (s *HomeService) CountInfo(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if postgresqlInstalled {
-		server, err := s.databaseServerRepo.GetByName("local_postgresql")
-		if err == nil {
-			postgres, err := db.NewPostgres(server.Username, server.Password, server.Host, server.Port)
-			if err == nil {
+		if server, err := s.databaseServerRepo.GetByName("local_postgresql"); err == nil {
+			if postgres, err := db.NewPostgres(server.Username, server.Password, server.Host, server.Port); err == nil {
 				defer postgres.Close()
-				databases, err := postgres.Databases()
-				if err == nil {
+				if databases, err := postgres.Databases(); err == nil {
 					databaseCount += len(databases)
 				}
 			}

--- a/internal/service/home.go
+++ b/internal/service/home.go
@@ -31,34 +31,36 @@ import (
 )
 
 type HomeService struct {
-	t               *gotext.Locale
-	api             *api.API
-	conf            *config.Config
-	taskRepo        biz.TaskRepo
-	websiteRepo     biz.WebsiteRepo
-	projectRepo     biz.ProjectRepo
-	appRepo         biz.AppRepo
-	environmentRepo biz.EnvironmentRepo
-	settingRepo     biz.SettingRepo
-	cronRepo        biz.CronRepo
-	backupRepo      biz.BackupRepo
-	containerRepo   biz.ContainerRepo
+	t                  *gotext.Locale
+	api                *api.API
+	conf               *config.Config
+	taskRepo           biz.TaskRepo
+	websiteRepo        biz.WebsiteRepo
+	projectRepo        biz.ProjectRepo
+	appRepo            biz.AppRepo
+	environmentRepo    biz.EnvironmentRepo
+	settingRepo        biz.SettingRepo
+	databaseServerRepo biz.DatabaseServerRepo
+	cronRepo           biz.CronRepo
+	backupRepo         biz.BackupRepo
+	containerRepo      biz.ContainerRepo
 }
 
-func NewHomeService(t *gotext.Locale, conf *config.Config, task biz.TaskRepo, website biz.WebsiteRepo, project biz.ProjectRepo, appRepo biz.AppRepo, environment biz.EnvironmentRepo, setting biz.SettingRepo, cron biz.CronRepo, backupRepo biz.BackupRepo, container biz.ContainerRepo) *HomeService {
+func NewHomeService(t *gotext.Locale, conf *config.Config, task biz.TaskRepo, website biz.WebsiteRepo, project biz.ProjectRepo, appRepo biz.AppRepo, environment biz.EnvironmentRepo, setting biz.SettingRepo, databaseServer biz.DatabaseServerRepo, cron biz.CronRepo, backupRepo biz.BackupRepo, container biz.ContainerRepo) *HomeService {
 	return &HomeService{
-		t:               t,
-		api:             api.NewAPI(app.Version, app.Locale),
-		conf:            conf,
-		taskRepo:        task,
-		websiteRepo:     website,
-		projectRepo:     project,
-		appRepo:         appRepo,
-		environmentRepo: environment,
-		settingRepo:     setting,
-		cronRepo:        cron,
-		backupRepo:      backupRepo,
-		containerRepo:   container,
+		t:                  t,
+		api:                api.NewAPI(app.Version, app.Locale),
+		conf:               conf,
+		taskRepo:           task,
+		websiteRepo:        website,
+		projectRepo:        project,
+		appRepo:            appRepo,
+		environmentRepo:    environment,
+		settingRepo:        setting,
+		databaseServerRepo: databaseServer,
+		cronRepo:           cron,
+		backupRepo:         backupRepo,
+		containerRepo:      container,
 	}
 }
 
@@ -187,13 +189,15 @@ func (s *HomeService) CountInfo(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if postgresqlInstalled {
-		postgresPassword, _ := s.settingRepo.Get(biz.SettingKeyPostgresPassword)
-		postgres, err := db.NewPostgres("postgres", postgresPassword, "127.0.0.1", 5432)
+		server, err := s.databaseServerRepo.GetByName("local_postgresql")
 		if err == nil {
-			defer postgres.Close()
-			databases, err := postgres.Databases()
+			postgres, err := db.NewPostgres(server.Username, server.Password, server.Host, server.Port)
 			if err == nil {
-				databaseCount += len(databases)
+				defer postgres.Close()
+				databases, err := postgres.Databases()
+				if err == nil {
+					databaseCount += len(databases)
+				}
 			}
 		}
 	}


### PR DESCRIPTION

## 📑 Description
1. 修复`/apps/postgresql/load`接口使用固定端口5432连接postgresql，导致在修改了默认端口的情况下，接口报错的问题
2. 修复`/home/count_info`接口在统计postgresql数据库数量时，使用固定端口5432连接，导致在修改了默认端口的情况下，postgresql数据库因连接失败，不会被计入总数的问题


<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have added test cases for my code
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **改进功能**
  * 优化 PostgreSQL 配置管理，统一配置路径并更可靠地应用变更（根据端口差异选择重启或重载）。
  * 增强对自定义端口的支持：所有数据库操作和统计将使用实际配置的端口。
  * 将本地 PostgreSQL 端口变更同步到服务记录，保证仪表盘统计使用正确连接信息。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/acepanel/panel/pull/1636?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->